### PR TITLE
SERVER: Downgrade Python to v3.7.5 to prepare for OpenCV installation.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 aliases:
   - &docker_python
-    - image: circleci/python:3.8.0-buster
+    - image: circleci/python:3.7.5-buster
 
   - &restore_cache_python
     restore_cache:

--- a/config/api.Dockerfile
+++ b/config/api.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.0-buster
+FROM python:3.7.5-buster
 
 LABEL author=contact@tarangill.dev
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flake8>=3.7.9
 Flask>=1.1.1
 Flask-CORS>=3.0.8
+numpy>=1.17.4
 pydub==0.23.1
 pytest>=5.0.0

--- a/src/packages/audio_intensity/test_audio_intensity.py
+++ b/src/packages/audio_intensity/test_audio_intensity.py
@@ -34,7 +34,7 @@ def test_root_mean_square_threshold():
 
     # Test if the threshold is sufficiently close when we halve the sampling rate
     assert math.isclose(
-        audio_intensity_analyzer.get_rms_threshold(1, 10, 8),
-        audio_intensity_analyzer.get_rms_threshold(2, 10, 8),
+        audio_intensity_analyzer.get_rms_threshold(1, 0.8),
+        audio_intensity_analyzer.get_rms_threshold(2, 0.8),
         rel_tol=0.05
     )


### PR DESCRIPTION
OpenCV doesn't seem to support Python 3.8, which is what I was originally using 😢 . I'm just downgrading to prep for installing it inside production containers.

If you're not using Docker, then you'll need to make sure your host Python version is at most 3.7.5 for when we start integrating stuff